### PR TITLE
Update README and fix OpenSSL URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,23 +7,31 @@ In particular, this repository contains the code described and utilized in the
 papers:
 
 **"Computing Linear Restrictions of Neural Networks" ([1])**
-Preprint: [https://arxiv.org/abs/1908.06214](https://arxiv.org/abs/1908.06214).
+
+[Conference on Neural Information Processing Systems (NeurIPS)
+2019](https://neurips.cc/Conferences/2019)
+
+Links:
+[Paper](https://papers.nips.cc/paper/9562-computing-linear-restrictions-of-neural-networks),
+[Slides](https://zenodo.org/record/3520104),
+[Poster](https://zenodo.org/record/3520102)
 ```
-@article{sotoudeh:linear_restrictions,
-  author    = {Matthew Sotoudeh and Aditya V. Thakur},
-  title     = {Computing Linear Restrictions of Neural Networks},
-  journal   = {CoRR},
-  volume    = {abs/1908.06214},
-  year      = {2019},
-  url       = {https://arxiv.org/abs/1908.06214},
-  archivePrefix = {arXiv},
-  eprint    = {1908.06214},
+@incollection{sotoudeh:linear_restrictions,
+  title = {Computing Linear Restrictions of Neural Networks},
+  author = {Sotoudeh, Matthew and Thakur, Aditya V},
+  booktitle = {Advances in Neural Information Processing Systems 32},
+  editor = {H. Wallach and H. Larochelle and A. Beygelzimer and F. d\textquotesingle Alch\'{e}-Buc and E. Fox and R. Garnett},
+  pages = {14132--14143},
+  year = {2019},
+  publisher = {Curran Associates, Inc.},
+  url = {http://papers.nips.cc/paper/9562-computing-linear-restrictions-of-neural-networks.pdf}
 }
 ```
 
 **"A Symbolic Neural Network Representation and its Application to
 Understanding, Verifying, and Patching Networks" ([2])**
-Preprint: [https://arxiv.org/abs/1908.06223](https://arxiv.org/abs/1908.06223).
+
+Links: [Preprint](https://arxiv.org/abs/1908.06223)
 ```
 @article{sotoudeh:symbolic_networks,
   author    = {Matthew Sotoudeh and Aditya V. Thakur},
@@ -38,8 +46,23 @@ Preprint: [https://arxiv.org/abs/1908.06223](https://arxiv.org/abs/1908.06223).
 }
 ```
 
-We will refer to these as ``[1]`` and ``[2]`` respectively in comments and
-code.
+**"Correcting Deep Neural Networks with Small, Generalizing Patches ([3])**
+
+[NeurIPS 2019 Workshop on Safety and Robustness in Decision
+Making](https://sites.google.com/view/neurips19-safe-robust-workshop)
+
+Links: [Paper](https://drive.google.com/file/d/0B3mY6u_lryzdNTFaZnkzUzhuRDNnZG9rdDV5aDA2WFpBOWhN/view)
+```
+@inproceedings{sotoudeh:correcting_dnns_srdm19,
+  title={Correcting Deep Neural Networks with Small, Generalizing Patches},
+  author={Sotoudeh, Matthew and Thakur, Aditya V},
+  booktitle={NeurIPS 2019 Workshop on Safety and Robustness in Decision Making},
+  year={2019}
+}
+```
+
+We will refer to these as ``[1]``, ``[2]``, and ``[3]`` respectively in
+comments and code.
 
 ## Notation and Naming
 In the papers, we often use mathematical notation that can be hard/impossible

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -61,9 +61,9 @@ http_archive(
 http_archive(
     name = "mkldnn",
     build_file = "mkldnn.BUILD",
-    sha256 = "91fb84601c18f8a5a87eccd7b63d61f03495f36c5c533bd7f59443e4f8bb2595",
-    strip_prefix = "mkl-dnn-1.0.1",
-    urls = ["https://github.com/intel/mkl-dnn/archive/v1.0.1.tar.gz"],
+    sha256 = "8fee2324267811204c1f877a1dea70b23ab3d5f4c3ea0198d81f0921aa70d76e",
+    strip_prefix = "oneDNN-1.0.1",
+    urls = ["https://github.com/oneapi-src/oneDNN/archive/v1.0.1.tar.gz"],
 )
 
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,7 +9,7 @@ http_archive(
     build_file = "openssl.BUILD",
     sha256 = "cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96",
     strip_prefix = "openssl-1.0.2s",
-    urls = ["https://www.openssl.org/source/openssl-1.0.2s.tar.gz"],
+    urls = ["https://www.openssl.org/source/old/1.0.2/openssl-1.0.2s.tar.gz"],
 )
 
 http_archive(
@@ -166,13 +166,6 @@ http_file(
     downloaded_file_path = "model.eran",
     sha256 = "88c414a0f69a3469731c45bc14d9583cb8189fbbbab003ca70d818a041a31103",
     urls = ["https://files.sri.inf.ethz.ch/eran/nets/pytorch/mnist/convMedGRELU__Point.pyt"],
-)
-
-http_file(
-    name = "mnist_relu_convmedium_diffai_model",
-    downloaded_file_path = "model.eran",
-    sha256 = "",
-    urls = ["https://files.sri.inf.ethz.ch/eran/nets/pytorch/mnist/convMedGRELU__DiffAI.pyt"],
 )
 
 http_file(


### PR DESCRIPTION
This PR updates the README to link to our published papers and presentations, and fixes an outdated OpenSSL source code URL.