### PR TITLE
Update the Bazel dependency on `bazel_python`.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,7 +5,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "bazel_python",
-    commit = "cb4f346641afd090dc088c01df46dc403e600773",
+    commit = "538f6cfd5acdb2b5adfd7742d59ae196367b04dc",
     remote = "https://github.com/95616ARG/bazel_python.git",
 )
 


### PR DESCRIPTION
The previous version of `bazel_python` was causing an issue when running SyReNN's experiments, and has been fixed in 95616ARG/bazel_python#13.

Updating the SyReNN's Bazel dependency on `bazel_python` to the fixed version (95616ARG/bazel_python@538f6cfd5acdb2b5adfd7742d59ae196367b04dc).
